### PR TITLE
fix(elements): fix bottom-tabs z-index problem (#10064)

### DIFF
--- a/packages/elements/src/SafeAreaProviderCompat.tsx
+++ b/packages/elements/src/SafeAreaProviderCompat.tsx
@@ -39,7 +39,7 @@ export default function SafeAreaProviderCompat({ children, style }: Props) {
           // If we already have insets, don't wrap the stack in another safe area provider
           // This avoids an issue with updates at the cost of potentially incorrect values
           // https://github.com/react-navigation/react-navigation/issues/174
-          return <View style={[styles.container, style]}>{children}</View>;
+          return children;
         }
 
         return (


### PR DESCRIPTION
## Issue

Fixing https://github.com/react-navigation/react-navigation/issues/10064 issue.

## Problem

The issue is due to a change in this PR [ #9793 ]  `line 42`. Where the children were wrapped in a `View` Component. The `zIndex` behavior will not work since the `children` elements are not at the same level.

 Also Wrapping the children in a View is not necessary to achieve the wanted behavior of PR #9793,

<img width="879" alt="Screenshot 2021-12-22 at 13 16 46" src="https://user-images.githubusercontent.com/90264248/147091545-6aea6cd9-1e81-4377-a3e5-21a05178f0d3.png">





## Proposition


**I suggest** either

-  We create the same SafeAreaProviderCompat component variation for bottom-tabs as it was before as it is now in this PR.

- Or add a `flatChildren` prop and make the behavior conditional. Where there will be no View wrapping If `flatChildren` is `true`. That can give flexibility for the SafeAreaProviderCompat and make sure we do not break anything.



